### PR TITLE
Bugfix/json map full urls

### DIFF
--- a/map.go
+++ b/map.go
@@ -130,7 +130,7 @@ func loadMapJSON(f io.Reader) (map[string]string, error) {
 			sb.WriteString(file.Preinstalled)
 		}
 
-		if file.Extension == "img.xz" {
+		if strings.HasSuffix(file.Extension, "img.xz") {
 			m[sb.String()] = u.Path
 		}
 

--- a/map_test.go
+++ b/map_test.go
@@ -1,12 +1,10 @@
 package redirector
 
 import (
-	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	log "github.com/sirupsen/logrus"
 )
 
 var _ = Describe("Map", func() {
@@ -38,12 +36,11 @@ var _ = Describe("Map", func() {
 
 		m, err := loadMapJSON(strings.NewReader(data))
 
-		log.Println(m)
 		Expect(err).To(BeNil())
-		Expect(m["aml-s9xx-box/Bookworm_current"]).To(Equal("https://dl.armbian.com/aml-s9xx-box/archive/Armbian_23.11.1_Aml-s9xx-box_bookworm_current_6.1.63.img.xz"))
+		Expect(m["aml-s9xx-box/Bookworm_current"]).To(Equal("/aml-s9xx-box/archive/Armbian_23.11.1_Aml-s9xx-box_bookworm_current_6.1.63.img.xz"))
 	})
 
-	It("Should successfully load the map from a JSON file", func() {
+	It("Should successfully load the map from a JSON file, rewriting extension paths as necessary", func() {
 		data := `{
   "assets": [
     {
@@ -90,15 +87,9 @@ var _ = Describe("Map", func() {
 
 		m, err := loadMapJSON(strings.NewReader(data))
 
-		log.Println(m)
-
-		for k, v := range m {
-			fmt.Printf("%s => %s\n", k, v)
-		}
-
 		Expect(err).To(BeNil())
-		Expect(m["khadas-vim1/Bookworm_current_xfce"]).To(Equal("https://dl.armbian.com/khadas-vim1/archive/Armbian_23.11.1_Khadas-vim1_bookworm_current_6.1.63_xfce_desktop.img.xz"))
-		Expect(m["khadas-vim1/Bookworm_current_xfce.sha"]).To(Equal("https://dl.armbian.com/khadas-vim1/archive/Armbian_23.11.1_Khadas-vim1_bookworm_current_6.1.63_xfce_desktop.img.xz.sha"))
-		Expect(m["khadas-vim1/Bookworm_current_xfce-test"]).To(Equal("https://dl.armbian.com/khadas-vim1/archive/Armbian_23.11.1_Khadas-vim1_bookworm_current_6.1.63_xfce_desktop.img.xz"))
+		Expect(m["khadas-vim1/Bookworm_current_xfce"]).To(Equal("/khadas-vim1/archive/Armbian_23.11.1_Khadas-vim1_bookworm_current_6.1.63_xfce_desktop.img.xz"))
+		Expect(m["khadas-vim1/Bookworm_current_xfce.sha"]).To(Equal("/khadas-vim1/archive/Armbian_23.11.1_Khadas-vim1_bookworm_current_6.1.63_xfce_desktop.img.xz.sha"))
+		Expect(m["khadas-vim1/Bookworm_current_xfce-test"]).To(Equal("/khadas-vim1/archive/Armbian_23.11.1_Khadas-vim1_bookworm_current_6.1.63_xfce_desktop.img.xz"))
 	})
 })

--- a/map_test.go
+++ b/map_test.go
@@ -92,4 +92,59 @@ var _ = Describe("Map", func() {
 		Expect(m["khadas-vim1/Bookworm_current_xfce.sha"]).To(Equal("/khadas-vim1/archive/Armbian_23.11.1_Khadas-vim1_bookworm_current_6.1.63_xfce_desktop.img.xz.sha"))
 		Expect(m["khadas-vim1/Bookworm_current_xfce-test"]).To(Equal("/khadas-vim1/archive/Armbian_23.11.1_Khadas-vim1_bookworm_current_6.1.63_xfce_desktop.img.xz"))
 	})
+	It("Should work with files that have weird extensions", func() {
+		data := `{
+  "assets": [
+    {
+      "board_slug": "khadas-vim4",
+      "armbian_version": "23.11.1",
+      "file_url": "https://dl.armbian.com/khadas-vim4/archive/Armbian_23.11.1_Khadas-vim4_bookworm_legacy_5.4.180.oowow.img.xz",
+      "file_updated": "2023-11-30T01:03:05Z",
+      "file_size": "477868032",
+      "distro_release": "bookworm",
+      "kernel_branch": "legacy",
+      "image_variant": "server",
+      "preinstalled_application": "",
+      "promoted": "true",
+      "download_repository": "archive",
+      "file_extension": "oowow.img.xz"
+    },
+    {
+      "board_slug": "khadas-vim4",
+      "armbian_version": "23.11.1",
+      "file_url": "https://dl.armbian.com/khadas-vim4/archive/Armbian_23.11.1_Khadas-vim4_bookworm_legacy_5.4.180.oowow.img.xz.asc",
+      "file_updated": "2023-11-30T01:03:05Z",
+      "file_size": "833",
+      "distro_release": "bookworm",
+      "kernel_branch": "legacy",
+      "image_variant": "server",
+      "preinstalled_application": "",
+      "promoted": "true",
+      "download_repository": "archive",
+      "file_extension": "oowow.img.xz.asc"
+    },
+    {
+      "board_slug": "khadas-vim4",
+      "armbian_version": "23.11.1",
+      "file_url": "https://dl.armbian.com/khadas-vim4/archive/Armbian_23.11.1_Khadas-vim4_bookworm_legacy_5.4.180.oowow.img.xz.sha",
+      "file_updated": "2023-11-30T01:03:05Z",
+      "file_size": "178",
+      "distro_release": "bookworm",
+      "kernel_branch": "legacy",
+      "image_variant": "server",
+      "preinstalled_application": "",
+      "promoted": "true",
+      "download_repository": "archive",
+      "file_extension": "oowow.img.xz.sha"
+    }
+  ]
+}`
+
+		m, err := loadMapJSON(strings.NewReader(data))
+
+		Expect(err).To(BeNil())
+		Expect(m["khadas-vim4/Bookworm_legacy"]).To(Equal("/khadas-vim4/archive/Armbian_23.11.1_Khadas-vim4_bookworm_legacy_5.4.180.oowow.img.xz"))
+		Expect(m["khadas-vim4/Bookworm_legacy.asc"]).To(Equal("/khadas-vim4/archive/Armbian_23.11.1_Khadas-vim4_bookworm_legacy_5.4.180.oowow.img.xz.asc"))
+		Expect(m["khadas-vim4/Bookworm_legacy.sha"]).To(Equal("/khadas-vim4/archive/Armbian_23.11.1_Khadas-vim4_bookworm_legacy_5.4.180.oowow.img.xz.sha"))
+	})
 })


### PR DESCRIPTION
Fixes the JSON mapping by removing the full URL scheme/host. By passing a full URL, we're simply pushing it to another redirector instance and ignoring the redirector's logic, which would require rewriting the redirection handler to efficiently handle.

This is the simpler of the two patches, as long as the server list is maintained on redirect.armbian.com as well as dl.armbian.com this will return the same results, without the extra redirect.