### PR TITLE
Fix Docker Build Compilation & Enable ARM64 Platform Support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
 
       # Upload artifacts
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4.6.0
         with:
           name: binaries
           path: build/

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -42,7 +42,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           pull: true
           push: true
           labels: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:alpine AS builder
 WORKDIR /src
 
 # Copy go mod and project files
-COPY go.* .
+COPY go.* ./
 RUN go mod download
 COPY . .
 


### PR DESCRIPTION
This pull request addresses the following:

- Docker Build Compilation: Resolves issues encountered during the Docker build process to ensure a smooth and error-free compilation.
- ARM64 Support: Introduces modifications to support the ARM64 architecture, allowing our build process to be executed successfully on ARM-based systems.
- Bump versioning: Updated upload-artifact to v4.6.0 in the workflow configuration.
