### PR TITLE
Improve mirror selection logic in Closest with full-server fallback

### DIFF
--- a/config.go
+++ b/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// CheckURL is the url used to verify mirror versions
 	CheckURL string `mapstructure:"checkUrl"`
 
+	// SameCityThreshold is the parameter used to specify a threshold between mirrors and the client
+	SameCityThreshold float64 `mapstructure:"sameCityThreshold"`
+
 	// ServerList is a list of ServerConfig structs, which gets parsed into servers.
 	ServerList []ServerConfig `mapstructure:"servers"`
 
@@ -158,6 +161,11 @@ func (r *Redirector) ReloadConfig() error {
 		r.config.TopChoices = 3
 	} else if r.config.TopChoices > len(r.servers) {
 		r.config.TopChoices = len(r.servers)
+	}
+
+    // Check if on the config is declared or use default logic
+	if r.config.SameCityThreshold == 0 {
+		r.config.SameCityThreshold = 200000.0
 	}
 
 	// Force check

--- a/dlrouter.yaml
+++ b/dlrouter.yaml
@@ -3,6 +3,8 @@ geodb: GeoLite2-City.mmdb
 asndb: GeoLite2-ASN.mmdb
 dl_map: userdata.csv
 
+sameCityThreshold: 200000.0
+
 checkUrl: https://imola.armbian.com/apt/.control
 
 # LRU Cache Size (in items)


### PR DESCRIPTION
This PR enhances the `Closest` function used for mirror selection by ensuring that **all** configured servers are considered, even when the initial filtering (based on availability, protocol, and rule checks) is too restrictive. It introduces a fallback mechanism, and more robust local mirror selection logic.

**Fixes:** Problems detecting nearest servers #15 

## Changes

- **Fallback Mechanism:**
  - If the filtered list of valid servers (i.e., servers that are available, support the required protocol, and pass rule checks) contains fewer than two mirrors, the function now falls back to using the full server list.
  - This ensures that all configured mirrors are considered during mirror selection.

- **Local Mirror Selection:**
  - After obtaining valid servers, the function filters for local servers (mirrors with the same country code as the client).
  - If at least one local mirror is found:
    - The distances are computed for each local mirror.
    - If the nearest local mirror is within a defined threshold (200 km), it is selected deterministically.
    - Otherwise, a weighted random selection is used among the local servers.
  - If no local mirrors are found, a weighted selection is performed among all valid servers.

- **Optional Rule Filtering:**
  - The current filtering of valid servers includes checks for availability, protocol support, and custom rules.
  - For debugging purposes, the rule filtering can be temporarily disabled to ensure all mirrors are taken into account.

## Impact

- **For Clients:**  
  Clients will now be more reliably directed to a local mirror when available, improving latency and download speed.

Please review the changes and let me know if further adjustments are needed.