### PR TITLE
Fix for servers being returned that are less performant than the closest

### DIFF
--- a/cmd/db/genaccessors.go
+++ b/cmd/db/genaccessors.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/armbian/redirector/db"
+	"github.com/armbian/redirector/geo"
 	"github.com/samber/lo"
 	"reflect"
 	"strings"
@@ -15,11 +15,11 @@ var (
 // This is a VERY messy way to generate static recursive field getters, which transform rule strings
 // into the field value
 func main() {
-	var asn db.ASN
+	var asn geo.ASN
 
 	accessors(asn)
 
-	var city db.City
+	var city geo.City
 
 	accessors(city)
 	accessors(city.Continent)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,7 +25,8 @@ func main() {
 
 	viper.SetDefault("bind", ":8080")
 	viper.SetDefault("cacheSize", 1024)
-	viper.SetDefault("topChoices", 3)
+	viper.SetDefault("topChoices", 1)
+	viper.SetDefault("maxDeviation", 50*1000) // 50 kilometers
 	viper.SetDefault("reloadKey", util.RandomSequence(32))
 
 	viper.SetConfigName("dlrouter")        // name of config file (without extension)

--- a/config.go
+++ b/config.go
@@ -47,8 +47,9 @@ type Config struct {
 	// CheckURL is the url used to verify mirror versions
 	CheckURL string `mapstructure:"checkUrl"`
 
-	// SameCityThreshold is the parameter used to specify a threshold between mirrors and the client
-	SameCityThreshold float64 `mapstructure:"sameCityThreshold"`
+	// MaxDeviation is used when we have multiple servers that could be used,
+	// but one or more may be too far from the others
+	MaxDeviation float64 `mapstructure:"maxDeviation"`
 
 	// ServerList is a list of ServerConfig structs, which gets parsed into servers.
 	ServerList []ServerConfig `mapstructure:"servers"`
@@ -163,7 +164,7 @@ func (r *Redirector) ReloadConfig() error {
 		r.config.TopChoices = len(r.servers)
 	}
 
-    // Check if on the config is declared or use default logic
+	// Check if on the config is declared or use default logic
 	if r.config.SameCityThreshold == 0 {
 		r.config.SameCityThreshold = 200000.0
 	}
@@ -230,7 +231,7 @@ func (r *Redirector) reloadServers() error {
 					"path":      u.Path,
 					"latitude":  s.Latitude,
 					"longitude": s.Longitude,
-					"country": s.Country,
+					"country":   s.Country,
 				}).Info("Added server")
 			}
 		}(i, server, u)

--- a/dlrouter.yaml
+++ b/dlrouter.yaml
@@ -3,7 +3,8 @@ geodb: GeoLite2-City.mmdb
 asndb: GeoLite2-ASN.mmdb
 dl_map: userdata.csv
 
-sameCityThreshold: 200000.0
+# Max distance to allow for other "nearby" servers
+maxDeviation: 50000
 
 checkUrl: https://imola.armbian.com/apt/.control
 

--- a/geo/accessors.go
+++ b/geo/accessors.go
@@ -1,4 +1,4 @@
-package db
+package geo
 
 import (
 	"regexp"

--- a/geo/geolocation.go
+++ b/geo/geolocation.go
@@ -1,0 +1,11 @@
+package geo
+
+import (
+	"net"
+)
+
+type Provider interface {
+	City(ip net.IP) (*City, error)
+	ASN(ip net.IP) (*ASN, error)
+	Close() error
+}

--- a/geo/maxmind.go
+++ b/geo/maxmind.go
@@ -1,0 +1,76 @@
+package geo
+
+import (
+	"fmt"
+	"github.com/oschwald/maxminddb-golang"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"net"
+)
+
+var ErrNoASN = errors.New("no asn database loaded")
+
+type MaxmindProvider struct {
+	db    *maxminddb.Reader
+	asnDB *maxminddb.Reader
+}
+
+func (m *MaxmindProvider) City(ip net.IP) (*City, error) {
+	var city City
+
+	if err := m.db.Lookup(ip, &city); err != nil {
+		return nil, err
+	}
+
+	return &city, nil
+}
+
+func (m *MaxmindProvider) ASN(ip net.IP) (*ASN, error) {
+	if m.asnDB == nil {
+		return nil, ErrNoASN
+	}
+
+	var asn ASN
+
+	if err := m.asnDB.Lookup(ip, &asn); err != nil {
+		log.WithError(err).Warning("Unable to load ASN information")
+		return nil, err
+	}
+
+	return &asn, nil
+}
+
+func (m *MaxmindProvider) Close() error {
+	if m.db != nil {
+		_ = m.db.Close()
+	}
+
+	if m.asnDB != nil {
+		_ = m.asnDB.Close()
+	}
+
+	return nil
+}
+
+func NewMaxmindProvider(geoPath, asnPath string) (Provider, error) {
+	// db can be hot-reloaded if the file changed
+	db, err := maxminddb.Open(geoPath)
+
+	if err != nil {
+		return nil, fmt.Errorf("unable to open geo database: %w", err)
+	}
+
+	var asnDB *maxminddb.Reader
+
+	if asnPath != "" {
+		asnDB, err = maxminddb.Open(asnPath)
+		if err != nil {
+			return nil, fmt.Errorf("unable to open asn database: %w", err)
+		}
+	}
+
+	return &MaxmindProvider{
+		db:    db,
+		asnDB: asnDB,
+	}, nil
+}

--- a/geo/mock.go
+++ b/geo/mock.go
@@ -1,0 +1,34 @@
+package geo
+
+import (
+	"github.com/stretchr/testify/mock"
+	"net"
+)
+
+type MockProvider struct {
+	mock.Mock
+}
+
+func (m *MockProvider) City(ip net.IP) (*City, error) {
+	args := m.Mock.Called(ip)
+
+	if v := args.Get(0); v != nil {
+		return v.(*City), args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
+func (m *MockProvider) ASN(ip net.IP) (*ASN, error) {
+	args := m.Mock.Called(ip)
+
+	if v := args.Get(0); v != nil {
+		return v.(*ASN), args.Error(1)
+	}
+
+	return nil, args.Error(1)
+}
+
+func (m *MockProvider) Close() error {
+	return nil
+}

--- a/geo/structs.go
+++ b/geo/structs.go
@@ -1,4 +1,4 @@
-package db
+package geo
 
 // City represents a MaxmindDB city.
 // This used to only be used on load, but is now used with rules as well.

--- a/go.mod
+++ b/go.mod
@@ -17,12 +17,14 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/sourcegraph/conc v0.3.0
 	github.com/spf13/viper v1.18.2
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/text v0.14.0
 )
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
@@ -32,6 +34,7 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.46.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
@@ -40,6 +43,7 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240119083558-1b970713d09a // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=
 github.com/spf13/viper v1.18.2/go.mod h1:EKmWIqdnk5lOcmR72yw6hS+8OPYcwD0jteitLMVB+yk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/http.go
+++ b/http.go
@@ -10,7 +10,6 @@ import (
 	"path"
 	"strings"
 
-	"github.com/armbian/redirector/db"
 	"github.com/jmcvetta/randutil"
 	log "github.com/sirupsen/logrus"
 )
@@ -205,8 +204,7 @@ func (r *Redirector) geoIPHandler(w http.ResponseWriter, req *http.Request) {
 
 	ip := net.ParseIP(ipStr)
 
-	var city db.City
-	err = r.db.Lookup(ip, &city)
+	city, err := r.geo.City(ip)
 
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/redirector.go
+++ b/redirector.go
@@ -1,11 +1,11 @@
 package redirector
 
 import (
+	"github.com/armbian/redirector/geo"
 	"github.com/armbian/redirector/middleware"
 	"github.com/chi-middleware/logrus-logger"
 	"github.com/go-chi/chi/v5"
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/oschwald/maxminddb-golang"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -28,8 +28,7 @@ var (
 // Redirector is our application instance.
 type Redirector struct {
 	config      *Config
-	db          *maxminddb.Reader
-	asnDB       *maxminddb.Reader
+	geo         geo.Provider
 	servers     ServerList
 	regionMap   map[string][]*Server
 	hostMap     map[string]*Server

--- a/servers_test.go
+++ b/servers_test.go
@@ -1,22 +1,261 @@
 package redirector
 
 import (
+	"encoding/json"
+	"github.com/armbian/redirector/geo"
+	lru "github.com/hashicorp/golang-lru"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	log "github.com/sirupsen/logrus"
+	"net"
 )
 
-var _ = Describe("Servers", func() {
-	It("Should successfully return the closest server", func() {
+// server1.example.com -> San Francisco, CA, USA (37.8749, -122.3194)
+// server2.example.ca -> Ottawa, ON, Canada (45.5215, -75.5972)
+// server3.example.com -> New York, NY, USA (40.8128, -73.906)
+// server4.example.ca -> Vancouver, BC, Canada (49.3827, -123.0207)
+// server5.example.com -> Los Angeles, CA, USA (34.1522, -118.1437)
+// server6.example.ca -> Calgary, AB, Canada (51.1447, -114.1719)
+// server7.example.com -> Chicago, IL, USA (41.9781, -87.5298)
+// server8.example.ca -> Edmonton, AB, Canada (53.6461, -113.3938)
+// server9.example.com -> Houston, TX, USA (29.8604, -95.2698)
+// server10.example.ca -> Toronto, ON, Canada (43.7532, -79.2832)
+// server11.example.com -> Chicago, IL, USA (42.1781, -87.7298) ~20km variation
+// server12.example.com -> Chicago, IL, USA (42.5781, -87.9298) ~50km variation
+// server13.example.com -> Detroit, MI, USA (42.3314, -83.0458)
+// server14.example.com -> Detroit, MI, USA (42.5314, -83.2458) ~20km variation
+const serverTestJson = `[
+  {
+    "available": true,
+    "host": "server1.example.com",
+    "latitude": 37.7749,
+    "longitude": -122.4194,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server2.example.ca",
+    "latitude": 45.4215,
+    "longitude": -75.6972,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server3.example.com",
+    "latitude": 40.7128,
+    "longitude": -74.006,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server4.example.ca",
+    "latitude": 49.2827,
+    "longitude": -123.1207,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server5.example.com",
+    "latitude": 34.0522,
+    "longitude": -118.2437,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server6.example.ca",
+    "latitude": 51.0447,
+    "longitude": -114.0719,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server7.example.com",
+    "latitude": 41.8781,
+    "longitude": -87.6298,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server8.example.ca",
+    "latitude": 53.5461,
+    "longitude": -113.4938,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server9.example.com",
+    "latitude": 29.7604,
+    "longitude": -95.3698,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server10.example.ca",
+    "latitude": 43.6532,
+    "longitude": -79.3832,
+	"weight": 10,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server11.example.com",
+    "latitude": 42.1781,
+    "longitude": -87.7298,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server12.example.com",
+    "latitude": 42.5781,
+    "longitude": -87.9298,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server13.example.com",
+    "latitude": 42.3314,
+    "longitude": -83.0458,
+    "protocols": ["http", "https"]
+  },
+  {
+    "available": true,
+    "host": "server14.example.com",
+    "latitude": 42.5314,
+    "longitude": -83.2458,
+    "protocols": ["http", "https"]
+  }
+]
+`
 
+var _ = Describe("Servers", func() {
+	var (
+		r            *Redirector
+		mockProvider *geo.MockProvider
+	)
+
+	BeforeEach(func() {
+		log.SetLevel(log.DebugLevel)
+		mockProvider = &geo.MockProvider{}
+		r = New(&Config{})
+		r.geo = mockProvider
+		r.serverCache, _ = lru.New(10)
+
+		err := json.Unmarshal([]byte(serverTestJson), &r.servers)
+
+		Expect(err).To(BeNil())
+	})
+
+	Context("Single server", func() {
+		BeforeEach(func() {
+			// Single server returns
+			r.config.TopChoices = 1
+		})
+		It("Should successfully return the closest server to San Francisco, CA", func() {
+			ip := net.IPv4(1, 2, 3, 4)
+
+			// This geolocations to San Francisco, CA, USA
+			mockProvider.On("City", ip).Return(&geo.City{
+				Location: geo.Location{Latitude: 37.8749, Longitude: -122.3194},
+			}, nil)
+			mockProvider.On("ASN", ip).Return(nil, geo.ErrNoASN)
+
+			closest, distance, err := r.servers.Closest(r, "https", ip)
+
+			Expect(err).To(BeNil())
+
+			// Expect the closest server to be server1.example.com with a distance of around 14185
+			Expect(closest.Host).To(Equal("server1.example.com"))
+
+			// Distance is calculated beforehand and should be the same no matter how many runs due to presets
+			Expect(int(distance)).To(Equal(14185))
+		})
 	})
 	Context("Round-Robin Balancing", func() {
-		It("Should successfully return the closest server, when other servers are too far", func() {
-
+		BeforeEach(func() {
+			// Multi server returns
+			r.config.TopChoices = 5
+			r.config.MaxDeviation = 50000 // 50km
 		})
-		It("Should successfully return the top servers if they are all in the same location/city", func() {
+		It("Should successfully return a server in the closest area, when other servers are too far", func() {
+			ip := net.IPv4(4, 3, 2, 1)
 
+			// Ottawa, CA
+			mockProvider.On("City", ip).Return(&geo.City{
+				Location: geo.Location{Latitude: 45.5215, Longitude: -75.5972},
+			}, nil)
+			mockProvider.On("ASN", ip).Return(nil, geo.ErrNoASN)
+
+			closest, distance, err := r.servers.Closest(r, "https", ip)
+
+			Expect(err).To(BeNil())
+
+			// This should ONLY return our Ottawa server due to the deviation setting
+			Expect(closest.Host).To(Equal("server2.example.ca"))
+
+			// This is the distance we expect
+			Expect(int(distance)).To(Equal(13596))
+		})
+		It("Should successfully return a close server and not one from outside our deviation range", func() {
+			ip := net.IPv4(4, 3, 2, 1)
+
+			// Ottawa, CA
+			mockProvider.On("City", ip).Return(&geo.City{
+				// Near Ann Arbor, MI - outside of Detroit
+				Location: geo.Location{Latitude: 42.2819, Longitude: -83.7538},
+			}, nil)
+			mockProvider.On("ASN", ip).Return(nil, geo.ErrNoASN)
+
+			choices, err := r.servers.Choices(r, "https", ip)
+
+			Expect(err).To(BeNil())
+
+			// Expect only the Detroit servers
+			Expect(len(choices)).To(Equal(2))
+
+			for _, choice := range choices {
+				item := choice.Item.(ComputedDistance)
+
+				Expect(item.Server.Host).To(BeElementOf("server13.example.com", "server14.example.com"))
+				Expect(item.Distance).To(BeNumerically("<", 60000))
+			}
 		})
 		It("Should successfully return the top servers if they are all within reasonable distance", func() {
 
+			ip := net.IPv4(4, 3, 2, 1)
+
+			// Ottawa, CA
+			mockProvider.On("City", ip).Return(&geo.City{
+				// Grand Rapids, MI - in between Detroit and Chicago
+				Location: geo.Location{Latitude: 42.9657, Longitude: -85.6774},
+			}, nil)
+			mockProvider.On("ASN", ip).Return(nil, geo.ErrNoASN)
+
+			choices, err := r.servers.Choices(r, "https", ip)
+
+			Expect(err).To(BeNil())
+
+			Expect(len(choices)).To(Equal(r.config.TopChoices))
+
+			for _, choice := range choices {
+				item := choice.Item.(ComputedDistance)
+
+				Expect(item.Server.Host).To(BeElementOf(
+					"server7.example.com",  // Chicago, IL, USA
+					"server11.example.com", // Chicago, IL, USA
+					"server12.example.com", // Chicago, IL, USA
+					"server13.example.com", // Detroit, MI
+					"server14.example.com", // Detroit, MI
+				))
+			}
 		})
 	})
 })

--- a/servers_test.go
+++ b/servers_test.go
@@ -1,0 +1,22 @@
+package redirector
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Servers", func() {
+	It("Should successfully return the closest server", func() {
+
+	})
+	Context("Round-Robin Balancing", func() {
+		It("Should successfully return the closest server, when other servers are too far", func() {
+
+		})
+		It("Should successfully return the top servers if they are all in the same location/city", func() {
+
+		})
+		It("Should successfully return the top servers if they are all within reasonable distance", func() {
+
+		})
+	})
+})

--- a/util/util.go
+++ b/util/util.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/armbian/redirector/db"
+	"github.com/armbian/redirector/geo"
 )
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -26,7 +26,7 @@ var (
 func GetValue(val any, key string) (any, bool) {
 	// Bypass reflection for known types
 	if strings.HasPrefix(key, "asn") || strings.HasPrefix(key, "city") {
-		return db.GetValue(val, key)
+		return geo.GetValue(val, key)
 	}
 
 	// Fallback to reflection
@@ -35,7 +35,7 @@ func GetValue(val any, key string) (any, bool) {
 
 // GetValue is a reflection helper like Laravel's data_get
 // It lets us use the syntax of some.field.nested in rules.
-// This is the slow path, see db.GetValue for the faster (somewhat generated) path
+// This is the slow path, see geo.GetValue for the faster (somewhat generated) path
 func getValueReflect(val any, key string) (any, bool) {
 	v := reflect.ValueOf(val)
 


### PR DESCRIPTION
This PR rewrites the `Closest` function to add a `MaxDeviation` field, which allows a configurable maximum distance from the closest server to be used. This will prevent issues when there's a close (<50km) server, and then the next two closest are 500km away.

Changes
--------

- Adds MaxDeviation (`maxDeviation` in yaml) which defaults to 50km
- Changes the default behavior to only return one server instead of a rotating list of three
- Reverts to caching all items in a slice instead of a single item to maintain flexibility, but keeps a "fast path" to bypass the random selection/weighting code.
- Removes `localServer` checks which could cause issues with countries that only have one server, or servers that are nowhere near the user. For example, if a server is in Vancouver, BC in Canada, and a user from Toronto wants to get a mirror, it would prefer and return the Vancouver mirror instead of a closer Chicago or New York one. This is resolved by using one server and the MaxDeviation fields.
