### PR TITLE
map: accept .tar.xz and register boot-payload / hyperv.zip.xz specialExtensions

### DIFF
--- a/dlrouter.yaml
+++ b/dlrouter.yaml
@@ -58,7 +58,15 @@ specialExtensions:
   boot-sms.img.xz: -boot-sms
   boot-boe.img.xz: -boot-boe
   boot-csot.img.xz: -boot-csot
+  # Boot payload companion files (generator emits "<flavor>.img.xz" after stripping
+  # the ".boot_<soc>-<board>-<flavor>" prefix; REDI_URL gets a "-<flavor>" suffix)
+  boe.img.xz: -boe
+  csot.img.xz: -csot
+  kebab.img.xz: -kebab
+  recovery.img.xz: -recovery
   rootfs.img.xz: -rootfs
+  # Hyper-V cloud images
+  hyperv.zip.xz: -hyperv
   img.qcow2: -qcow2
   img.qcow2.xz: -qcow2
   boot.bin.xz: -uboot-bin

--- a/map.go
+++ b/map.go
@@ -123,7 +123,7 @@ func loadMapJSON(f io.Reader, specialExtensions map[string]string) (map[string]s
 		}
 
 		imageExtensions := maps.Keys(specialExtensions)
-		imageExtensions = append(imageExtensions, "img.xz") // extra allocation, but it's fine
+		imageExtensions = append(imageExtensions, "img.xz", "tar.xz") // extra allocation, but it's fine
 
 		// Add board into the map without an extension
 		for _, ext := range imageExtensions {


### PR DESCRIPTION
Fixes armbian/armbian-router#39 and the router half of armbian/armbian.github.io#277.

## Problem

`loadMapJSON` only inserts an entry into the redirect map when `file.Extension` ends with `img.xz` or a key registered in `specialExtensions`. Two classes of image therefore 404 through the mirror even when the generator emits them correctly:

1. **`.tar.xz` images** (Arduino UNO Q community builds) — never map because `tar.xz` is not an accepted extension.
2. **Boot-payload companions and Hyper-V cloud images** — `boe.img.xz`, `csot.img.xz`, `kebab.img.xz`, `recovery.img.xz` and `hyperv.zip.xz` are not in `specialExtensions`, so `loadMapJSON` doesn't append the matching `-boe` / `-csot` / `-kebab` / `-recovery` / `-hyperv` suffix that the JSON generator already bakes into `redi_url`. The key stored in the map and the redirect URL therefore disagree.

The upstream audit in armbian/armbian.github.io#277 flagged 12 URLs broken across `arduino-uno-q`, `oneplus-kebab`, `xiaomi-elish`, `uefi-arm64` and `uefi-x86`.

## Fix (2 commits)

1. `map.go`: add `tar.xz` to the hardcoded `imageExtensions` list alongside `img.xz`. `.tar.xz` is a standard image format, not a companion file, so a hardcoded entry is the correct shape (Option A in the issue).
2. `dlrouter.yaml`: register the missing boot-payload and Hyper-V extensions with the suffixes emitted by the generator:
   - `boe.img.xz: -boe`
   - `csot.img.xz: -csot`
   - `kebab.img.xz: -kebab`
   - `recovery.img.xz: -recovery`
   - `hyperv.zip.xz: -hyperv`

The existing `boot-boe.img.xz` / `boot-csot.img.xz` / `boot-sms.img.xz` entries are kept untouched for backwards compatibility with any legacy artifact still in flight.

## Companion PR

The generator-side counterpart is armbian/armbian.github.io#... (PR linked from issue 277). For the Arduino UNO Q path to resolve end-to-end both PRs need to land and the production `dlrouter.yaml` (served via `armbian/actions` `make-yaml-redirector`) needs to mirror these entries.

## Related

- armbian/armbian-router#39
- armbian/armbian.github.io#277

/cc @igorpecovnik @efectn