### PR TITLE
ci: drop deprecated golint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,14 +38,12 @@ jobs:
       - name: Install dependencies
         run: |
           go version
-          go install -mod=mod golang.org/x/lint/golint
           go install -mod=mod github.com/onsi/ginkgo/v2/ginkgo
 
-      # Run vet & lint on the code
-      - name: Run vet & lint
+      # Run vet on the code
+      - name: Run vet
         run: |
           go vet .
-          golint .
 
       # Run testing on the code
       - name: Run testing


### PR DESCRIPTION
CI on master has been failing since the runner moved to Go 1.25:

```
x/tools@v0.17.0/internal/tokeninternal/tokeninternal.go:78:9: invalid array length -delta * delta
```

That comes from `go install golang.org/x/lint/golint`, which drags in an old `x/tools` that doesn't build on Go 1.25 anymore (see golang/go#74462). `golint` itself has been archived since 2021 and won't get a new release, so pinning won't help either.

Easiest thing is to just drop it — `go vet` already runs and covers most of what `golint` flagged. If you want a proper modern linter later, staticcheck slots in cleanly.

Reference failing run: https://github.com/armbian/armbian-router/actions/runs/24421454847/job/71344499583